### PR TITLE
Task/dosis 355 poc pipeline standup

### DIFF
--- a/.github/workflows/pipeline-deploy-is-application.yaml
+++ b/.github/workflows/pipeline-deploy-is-application.yaml
@@ -1,7 +1,7 @@
 name: Integrated Search Application Deployment Pipeline
 # Intended to run if
 # - dependabot PR is labelled Test Ready
-# - changes pushed to task branch
+# - changes pushed to task/DOSIS branch
 # - changes pushed to main branch
 on:
   push:

--- a/.github/workflows/pipeline-deploy-is-application.yaml
+++ b/.github/workflows/pipeline-deploy-is-application.yaml
@@ -1,0 +1,93 @@
+name: Integrated Search Application Deployment Pipeline
+# Intended to run if
+# - dependabot PR is labelled Test Ready
+# - changes pushed to task branch
+# - changes pushed to main branch
+on:
+  push:
+    branches:
+      - main
+      - 'task/DOSIS*'
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  metadata:
+    if: ( ${{ github.event.label.name == 'Test Ready' && startswith(github.head_ref, 'dependabot/') }} ) || ( ${{ github.event_name == 'push' }} && ( ${{ startswith(github.ref_name, 'task/') || startswith(github.ref_name, 'main') }} ) )
+    name: "Get Metadata"
+    uses: ./.github/workflows/metadata.yaml
+
+  quality-checks:
+    name: "Quality Check"
+    needs:
+      [
+        metadata,
+      ]
+    if: ${{ github.event_name == 'push' }}
+    uses: ./.github/workflows/quality-checks.yaml
+    with:
+      environment: ${{ needs.metadata.outputs.environment }}
+      workspace: ${{ needs.metadata.outputs.workspace }}
+      stacks: "['gp_search']"
+    secrets: inherit
+
+  deploy-infrastructure-plan:
+    name: "TF Plan IS level infrastructure"
+    needs:
+      [
+        metadata,
+        quality-checks,
+      ]
+    uses: ./.github/workflows/deploy-infrastructure.yaml
+    with:
+      environment: ${{ needs.metadata.outputs.environment }}
+      domain: ${{ needs.metadata.outputs.reponame }}
+      workspace: ${{ needs.metadata.outputs.workspace }}
+      tag: ${{ inputs.tag }}
+      stacks: "['gp_search']"
+      action: plan
+    secrets: inherit
+
+  manual-approval:
+    name: "Manual approval for IS level infrastructure deployment"
+    if: ${{ needs.deploy-infrastructure-plan.outputs.plan_result == 'true' }}
+    needs:
+      [
+        metadata,
+        deploy-infrastructure-plan,
+      ]
+    runs-on: ubuntu-latest
+    environment: "${{ needs.metadata.outputs.environment }}-protected"
+    steps:
+      - name: Approval required
+        run: echo "Deployment paused for manual approval. Please approve in the Actions tab."
+
+  deploy-is-account-infrastructure-apply:
+    name: "TFApply for IS  infrastructure"
+    needs:
+      [
+        metadata,
+        manual-approval,
+      ]
+    uses: ./.github/workflows/deploy-infrastructure.yaml
+    with:
+      environment: ${{ needs.metadata.outputs.environment }}
+      domain: ${{ needs.metadata.outputs.reponame }}
+      workspace: ${{ needs.metadata.outputs.workspace }}
+      tag: ${{ inputs.tag }}
+      stacks: "['gp_search']"
+      action: apply
+    secrets: inherit
+
+  slack-notifications:
+    name: "Send Notification to Slack"
+    needs: [
+      metadata,
+      quality-checks,
+      deploy-is-account-infrastructure-apply,
+    ]
+    if: always()
+    uses: ./.github/workflows/slack-notifications.yaml
+    with:
+      env: ${{ needs.metadata.outputs.environment }}
+    secrets: inherit

--- a/infrastructure/gp_search.tfvars
+++ b/infrastructure/gp_search.tfvars
@@ -1,0 +1,2 @@
+project               = "ftrs-dos-integrated-search"
+gp_search_bucket_name = "gp-search-s3"

--- a/infrastructure/stacks/gp_search/s3.tf
+++ b/infrastructure/stacks/gp_search/s3.tf
@@ -1,0 +1,4 @@
+module "s3" {
+  source      = "../../modules/s3"
+  bucket_name = "${var.project}-${var.gp_search_bucket_name}-${var.environment}"
+}

--- a/infrastructure/stacks/gp_search/variables.tf
+++ b/infrastructure/stacks/gp_search/variables.tf
@@ -1,0 +1,3 @@
+variable "gp_search_bucket_name" {
+  description = "Name of S3 bucket for the GP Search API POC pipeline test"
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Change to have a working pipeline for a new Integrated Search stack, with a working pipeline with security secrets scans, that will stand up infrastructure in the Dev account, in this instance a basic S3 bucket for the GP_Search POC.
Also additional fix to derive workspace script to allow branch names with -'s

The aims of the pipline are:
-Fire upon a push to a branch with the IS naming convention (i.e. task/DOSIS*) and ensure successful deployment to development environment 
-Run the scan-secrets action check to for secrets (just need to test to make sure this stage is run) 
-Deploy an S3 bucket to the development environment from IS service infrastructure stack inside infrastructure/stacks/gp_search

## Context

This is to start the POC work and build the basis for the POC to be built. By adding in this change, it will show how the pipeline will run to stand up the infra and the building blocks for the POC to start.

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
