### PR TITLE
Task/dosis 558 add allure report to api test framework

### DIFF
--- a/tests/api_automation/.gitignore
+++ b/tests/api_automation/.gitignore
@@ -1,2 +1,5 @@
 # Ignore Config for secrets
 config.yaml
+test_logs.log
+allure-results
+allure-reports

--- a/tests/api_automation/README.MD
+++ b/tests/api_automation/README.MD
@@ -45,7 +45,7 @@ Install Playwright browsers (required for API testing via Playwright)
 playwright install
 ```
 
-instaal allure to generate report
+install allure to generate report
 ```
 brew install allure
 ```

--- a/tests/api_automation/README.MD
+++ b/tests/api_automation/README.MD
@@ -45,6 +45,12 @@ Install Playwright browsers (required for API testing via Playwright)
 playwright install
 ```
 
+instaal allure to generate report
+```
+brew install allure
+```
+
+
 ### Configuration
 
 Make a copy of config-template.yaml and name it config.yaml, and update it with API details as explained below:

--- a/tests/api_automation/README.MD
+++ b/tests/api_automation/README.MD
@@ -65,11 +65,11 @@ venv\Scripts\activate      # On Windows
 ## Running Tests
 
 ```
-pytest tests/step_definitions/test_s3_bucket.py -p allure_pytest_bdd --alluredir=allure-results
+pytest
 ```
 To run the tests and save the report results to a folder called allure-results
 ```
-pytest -p allure_pytest_bdd --alluredir=allure-results
+allure generate --single-file -c -o allure-reports allure-results
 ```
 
 ## Generating Reports

--- a/tests/api_automation/README.MD
+++ b/tests/api_automation/README.MD
@@ -64,23 +64,19 @@ venv\Scripts\activate      # On Windows
 
 ## Running Tests
 
-Run all tests using:
 ```
-pytest -v -s --html=report.html --self-contained-html --tb=short --capture=sys
+pytest tests/step_definitions/test_s3_bucket.py -p allure_pytest_bdd --alluredir=allure-results
 ```
-Run specific feature tests:
-
+To run the tests and save the report results to a folder called allure-results
 ```
-pytest tests/step_definitions/test_api_google_search.py --html=reports/report.html --self-contained-html
+pytest -p allure_pytest_bdd --alluredir=allure-results
 ```
 
 ## Generating Reports
 
-After execution, open the generated report:
-
+To generate a single page report in the folder allure-report
 ```
-open reports/report.html  # macOS/Linux
-start reports\report.html  # Windows
+allure generate --single-file -c -o allure-reports allure-results
 ```
 
 ## CI/CD Integration
@@ -88,9 +84,7 @@ start reports\report.html  # Windows
 To integrate with CI/CD pipelines, use:
 
 ```
-pytest -v -s --html=report.html --self-contained-html --tb=short --capture=sys;
-
-pytest --html=reports/report_$(date +%Y%m%d_%H%M%S).html --self-contained-html
+pytest -p allure_pytest_bdd --alluredir=allure-results
 ```
 
 This ensures unique report generation per run.

--- a/tests/api_automation/pytest.ini
+++ b/tests/api_automation/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --html=report.html -s --self-contained-html --maxfail=1 --disable-warnings -q --showlocals --setup-show
+addopts = --alluredir=allure-results --clean-alluredir
 log_cli = true
 log_level = INFO
 testpaths = api_automation/tests/step-definitions

--- a/tests/api_automation/pytest.ini
+++ b/tests/api_automation/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --alluredir=allure-results --clean-alluredir
+addopts = -p allure_pytest_bdd --alluredir=allure-results  --clean-alluredir
 log_cli = true
 log_level = INFO
 testpaths = api_automation/tests/step-definitions

--- a/tests/api_automation/tests/conftest.py
+++ b/tests/api_automation/tests/conftest.py
@@ -1,7 +1,5 @@
 import pytest
-import json
 import os
-import allure
 from loguru import logger
 from playwright.sync_api import sync_playwright
 import pytest_html

--- a/tests/api_automation/tests/conftest.py
+++ b/tests/api_automation/tests/conftest.py
@@ -1,9 +1,19 @@
 import pytest
 import json
 import os
+import allure
+from loguru import logger
 from playwright.sync_api import sync_playwright
 import pytest_html
 
+# Configure Loguru to log into a file and console
+logger.add("test_logs.log", rotation="1 day", level="INFO", backtrace=True, diagnose=True)
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_logging():
+    logger.info("Starting test session...")
+    yield
+    logger.info("Test session completed.")
 
 @pytest.fixture(scope="session")
 def playwright():

--- a/tests/api_automation/tests/step_definitions/test_api_google_search.py
+++ b/tests/api_automation/tests/step_definitions/test_api_google_search.py
@@ -1,6 +1,5 @@
 import pytest
 import json
-import allure
 from loguru import logger
 from pytest_bdd import given, when, then, scenarios
 from playwright.sync_api import sync_playwright
@@ -42,8 +41,7 @@ def prepare_google_search_request(api_response):
     api_response["base_url"] = base_url
     api_response["params"] = params
     api_response["request"] = json.dumps(params, indent=2)
-    with allure.step(f"api response: {api_response}"):
-        logger.info("api response", api_response)
+    logger.info("api response", api_response)
 
 @when("I receive the response")
 def make_google_search_request(api_request_context, api_response):
@@ -53,13 +51,11 @@ def make_google_search_request(api_request_context, api_response):
     base_url = api_response.get("base_url")
     params = api_response.get("params")
 
-    with allure.step(f"base url: {base_url}"):
-        logger.info("base url:", base_url)
+    logger.info("base url:", base_url)
 
     # Make the GET request (using Playwright's APIRequestContext)
     response = api_request_context.get(base_url, params=params)
-    with allure.step(f"respose: {response}"):
-        logger.info("response:", response)
+    logger.info("response:", response)
 
 
     # Store response status and body for logging
@@ -67,21 +63,16 @@ def make_google_search_request(api_request_context, api_response):
     try:
         response_json = response.json()
         api_response["response_body"] = json.dumps(response_json, indent=2)
-        with allure.step(f"respose: {api_response["response_body"]}"):
-            logger.info("response:", api_response["response_body"])
+        logger.info("response:", api_response["response_body"])
     except Exception as e:
         pytest.fail(f"Invalid JSON response: {e}")
-        with allure.step(f"Invalid JSON: {e}"):
-            logger.info("Invalid JSON:", e)
+        logger.info("Invalid JSON:", e)
         return
 
     # Print request & response in log
-    with allure.step(f"--- API Request ---: {json.dumps(params, indent=2)}"):
-            logger.info(f"--- API Request ---: {json.dumps(params, indent=2)}")
-    with allure.step(f"Status Code: {response.status}"):
-            logger.info(f"Status Code: {response.status}")
-    with allure.step(f"--- API Response ---: {json.dumps(response_json, indent=2)}"):
-            logger.info(f"--- API Response ---: {json.dumps(response_json, indent=2)}")
+    logger.info(f"--- API Request ---: {json.dumps(params, indent=2)}")
+    logger.info(f"Status Code: {response.status}")
+    logger.info(f"--- API Response ---: {json.dumps(response_json, indent=2)}")
 
     # Store the response for validation in the @then step
     api_response["response_json"] = response_json
@@ -91,20 +82,16 @@ def verify_response_and_search_results(api_response):
     """Verify the response status and search results contain 'Playwright'"""
     response_json = api_response.get("response_json", {})
     # Ensure response is valid
-    with allure.step(f"Status Code:"):
-        assert api_response["response_status"] == 200, \
-            f"Unexpected status code: {api_response['response_status']}"
+    assert api_response["response_status"] == 200, \
+        f"Unexpected status code: {api_response['response_status']}"
     # Assert that 'title' matches the expected value
-    with allure.step(f"title:"):
-        assert response_json.get("queries", {}).get("request", [{}])[0].get("title") == "Google Custom Search - Playwright", \
-            f"Expected 'title' to be 'Google Custom Search - Playwright', but got {response_json.get('queries', {}).get('request', [{}])[0].get('title')}"
+    assert response_json.get("queries", {}).get("request", [{}])[0].get("title") == "Google Custom Search - Playwright", \
+        f"Expected 'title' to be 'Google Custom Search - Playwright', but got {response_json.get('queries', {}).get('request', [{}])[0].get('title')}"
 
     # Assert that 'searchTerms' matches the expected value
-    with allure.step(f"searchTerms:"):
-        assert response_json.get("queries", {}).get("request", [{}])[0].get("searchTerms") == "Playwright", \
-            f"Expected 'searchTerms' to be 'Playwright', but got {response_json.get('queries', {}).get('request', [{}])[0].get('searchTerms')}"
+    assert response_json.get("queries", {}).get("request", [{}])[0].get("searchTerms") == "Playwright", \
+        f"Expected 'searchTerms' to be 'Playwright', but got {response_json.get('queries', {}).get('request', [{}])[0].get('searchTerms')}"
 
     # Assert that 'count' matches the expected value
-    with allure.step(f"count:"):
-        assert response_json.get("queries", {}).get("request", [{}])[0].get("count") == 10, \
-            f"Expected 'count' to be 10, but got {response_json.get('queries', {}).get('request', [{}])[0].get('count')}"
+    assert response_json.get("queries", {}).get("request", [{}])[0].get("count") == 10, \
+        f"Expected 'count' to be 10, but got {response_json.get('queries', {}).get('request', [{}])[0].get('count')}"

--- a/tests/infra_automation/.gitignore
+++ b/tests/infra_automation/.gitignore
@@ -1,2 +1,5 @@
 # Ignore Config for secrets
 config.yaml
+tesy_logs.log
+allure-results
+allure-reports

--- a/tests/infra_automation/.gitignore
+++ b/tests/infra_automation/.gitignore
@@ -1,5 +1,5 @@
 # Ignore Config for secrets
 config.yaml
-tesy_logs.log
+test_logs.log
 allure-results
 allure-reports

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -91,14 +91,18 @@ venv\Scripts\activate      # On Windows
 
 ## Running Tests
 
-Run all tests using:
-```
-pytest -v -s --html=report.html --self-contained-html --tb=short --capture=sys
-```
 Run specific feature tests:
 
 ```
-pytest tests/step_definitions/test_s3_bucket.py --html=reports/report.html --self-contained-html
+pytest tests/step_definitions/test_s3_bucket.py -p allure_pytest_bdd --alluredir=allure-results
+```
+To run the tests and save the report results to a folder called allure-results
+```
+pytest -p allure_pytest_bdd --alluredir=allure-results
+```
+To generate a single page report in the folder allure-report
+```
+allure generate --single-file -c -o allure-reports allure-results
 ```
 
 ## Using the Variables Locally
@@ -120,11 +124,9 @@ export ENV=dev
 
 ## Generating Reports
 
-After execution, open the generated report:
-
+To generate a single page report in the folder allure-report
 ```
-open reports/report.html  # macOS/Linux
-start reports\report.html  # Windows
+allure generate --single-file -c -o allure-reports allure-results
 ```
 
 ## CI/CD Integration
@@ -132,13 +134,10 @@ start reports\report.html  # Windows
 To integrate with CI/CD pipelines, use:
 
 ```
-pytest -v -s --html=report.html --self-contained-html --tb=short --capture=sys;
-
-pytest --html=reports/report_$(date +%Y%m%d_%H%M%S).html --self-contained-html
+pytest -p allure_pytest_bdd --alluredir=allure-results
 ```
 
 This ensures unique report generation per run.
 
 ## Troubleshooting
 If HTML reports are blank, ensure you use --self-contained-html in pytest options.
-

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -115,7 +115,7 @@ Project and Service-name should be set in the config file of the framework
 Set environment variables that are derived in the pipeline
 ```
 export WORKSPACE=dr-999  (where dr-999 is the branch name)
-export ENVIRONMENT=dev
+export ENV=dev
 ```
 
 ## Generating Reports

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -119,7 +119,7 @@ Project and Service-name should be set in the config file of the framework
 Set environment variables that are derived in the pipeline
 ```
 export WORKSPACE=dr-999  (where dr-999 is the branch name)
-export ENV=dev
+export env=dev
 ```
 
 ## Generating Reports

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -94,11 +94,12 @@ venv\Scripts\activate      # On Windows
 Run specific feature tests:
 
 ```
-pytest tests/step_definitions/test_s3_bucket.py -p allure_pytest_bdd --alluredir=allure-results
+pytest tests/step_definitions/test_s3_bucket.py
 ```
 To run the tests and save the report results to a folder called allure-results
 ```
-pytest -p allure_pytest_bdd --alluredir=allure-results
+pytest
+allure generate --single-file -c -o allure-reports allure-results
 ```
 To generate a single page report in the folder allure-report
 ```
@@ -120,6 +121,10 @@ Set environment variables that are derived in the pipeline
 ```
 export WORKSPACE=dr-999  (where dr-999 is the branch name)
 export ENV=dev
+```
+set PYTHONPATH to run test from tests folder from infra project and access utilities
+```
+export PYTHONPATH=$(pwd)../../../
 ```
 
 ## Generating Reports

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -128,7 +128,7 @@ export ENV=dev
 ```
 set PYTHONPATH to run test from tests folder from infra project and access utilities
 ```
-ecd <repo>/tests/infra_automation/tests
+cd <repo>/tests/infra_automation/tests
 export PYTHONPATH=$(pwd)/../../
 ```
 

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -103,7 +103,6 @@ pytest tests/step_definitions/test_s3_bucket.py
 To run the tests and save the report results to a folder called allure-results
 ```
 pytest
-allure generate --single-file -c -o allure-reports allure-results
 ```
 To generate a single page report in the folder allure-report
 ```

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -128,7 +128,8 @@ export ENV=dev
 ```
 set PYTHONPATH to run test from tests folder from infra project and access utilities
 ```
-export PYTHONPATH=$(pwd)../../../
+ecd <repo>/tests/infra_automation/tests
+export PYTHONPATH=$(pwd)/../../
 ```
 
 ## Generating Reports

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -119,7 +119,7 @@ Project and Service-name should be set in the config file of the framework
 Set environment variables that are derived in the pipeline
 ```
 export WORKSPACE=dr-999  (where dr-999 is the branch name)
-export env=dev
+export ENV=dev
 ```
 
 ## Generating Reports

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -51,6 +51,11 @@ brew install awscli  # macOS
 sudo apt install awscli  # Linux
 ```
 
+instaal allure to generate report
+```
+brew install allure
+```
+
 ### aws Configuration
 Make sure your AWS CLI is configured and authenticated:
 ```

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -51,7 +51,7 @@ brew install awscli  # macOS
 sudo apt install awscli  # Linux
 ```
 
-instaal allure to generate report
+install allure to generate report
 ```
 brew install allure
 ```

--- a/tests/infra_automation/README.MD
+++ b/tests/infra_automation/README.MD
@@ -77,7 +77,6 @@ change aws config file with values listed in Service Teams - Set up SSO for AWS 
 
 Make a copy of config_template.yaml and name it config.yaml, and update it with API details as explained below:
 ```
-bucket_type: "Bucket Name which need to locate"
 project: "aws project name"
 ```
 

--- a/tests/infra_automation/pytest.ini
+++ b/tests/infra_automation/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --html=report.html -s --self-contained-html --maxfail=1 --disable-warnings -q --showlocals --setup-show
+addopts = --alluredir=allure-results --clean-alluredir
 log_cli = true
 log_level = INFO
 testpaths = infra_automation/tests/step-definitions

--- a/tests/infra_automation/pytest.ini
+++ b/tests/infra_automation/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --alluredir=allure-results --clean-alluredir
+addopts = -p allure_pytest_bdd --alluredir=allure-results  --clean-alluredir
 log_cli = true
 log_level = INFO
 testpaths = infra_automation/tests/step-definitions

--- a/tests/infra_automation/tests/config_template.yaml
+++ b/tests/infra_automation/tests/config_template.yaml
@@ -2,13 +2,10 @@ environment: "dev"
 
 environments:
   dev:
-    bucket_type:
     project:
 
   nonprod:
-    bucket:
     project:
 
   prod:
-    bucket:
     project:

--- a/tests/infra_automation/tests/conftest.py
+++ b/tests/infra_automation/tests/conftest.py
@@ -1,8 +1,19 @@
 import pytest
 import os
+import allure
+from loguru import logger
 from playwright.sync_api import sync_playwright
 import pytest_html
 
+
+# Configure Loguru to log into a file and console
+logger.add("test_logs.log", rotation="1 day", level="INFO", backtrace=True, diagnose=True)
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_logging():
+    logger.info("Starting test session...")
+    yield
+    logger.info("Test session completed.")
 
 @pytest.fixture(scope="session")
 def playwright():

--- a/tests/infra_automation/tests/conftest.py
+++ b/tests/infra_automation/tests/conftest.py
@@ -28,10 +28,6 @@ def api_request_context(playwright):
     request_context.dispose()
 
 @pytest.fixture
-def bucket_type():
-    return 'standard'
-
-@pytest.fixture
 def api_response():
     """Fixture to store API response for logging in reports."""
     return {}

--- a/tests/infra_automation/tests/conftest.py
+++ b/tests/infra_automation/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import os
-import allure
 from loguru import logger
 from playwright.sync_api import sync_playwright
 import pytest_html

--- a/tests/infra_automation/tests/features/test_s3_bucket.feature
+++ b/tests/infra_automation/tests/features/test_s3_bucket.feature
@@ -8,4 +8,4 @@ Feature: S3 Bucket Name Validation
 
   Scenario: Check that specific bucket exists
     Given I am authenticated with AWS CLI
-    Then The S3 bucket "gp-search-bucket" exists
+    Then The S3 bucket "gp-search-s3" exists

--- a/tests/infra_automation/tests/features/test_s3_bucket.feature
+++ b/tests/infra_automation/tests/features/test_s3_bucket.feature
@@ -8,4 +8,4 @@ Feature: S3 Bucket Name Validation
 
   Scenario: Check that specific bucket exists
     Given I am authenticated with AWS CLI
-    Then The S3 bucket exists
+    Then The S3 bucket "gp-search-bucket" exists

--- a/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
+++ b/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
@@ -37,7 +37,7 @@ def confirm_s3_bucket_exists(bucket_type, aws_s3_client, workspace, env):
     else:
         bucket_name = project + "-" + bucket + "-" + env + "-" + workspace
     response = aws_s3_client.check_bucket_exists(bucket_name)
-    logger.info("Bucket Exits: {}", response)
+    logger.info("Bucket Exists: {}", response)
     assert response == True
 
 @when("I fetch the list of S3 buckets")
@@ -52,7 +52,7 @@ def validate_bucket_names(fetch_s3_buckets):
     logger.info("Available Buckets: {}", bucket_names)
     assert bucket_names, "No buckets found!"
     for bucket in bucket_names:
-        logger.info("Valid Bucket Names: {}", bucket_names)
+        logger.info("Valid Bucket Names: {}", bucket)
         assert 3 <= len(bucket) <= 63, f"Invalid length for bucket {bucket}"
         assert bucket.islower(), f"Bucket {bucket} must be lowercase"
         assert bucket[0].isalnum() and bucket[-1].isalnum(), f"Bucket {bucket} must start & end with letter/number"

--- a/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
+++ b/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
@@ -27,10 +27,10 @@ def check_aws_access():
     assert result.returncode == 0, f"Failed to authenticate with AWS CLI: {result.stderr}"
 
 
-@then(parsers.parse('The S3 bucket "{bucket_type}" exists'), target_fixture='fbucket_type')
-def confirm_s3_bucket_exists(bucket_type, aws_s3_client, workspace, env):
+@then(parsers.parse('The S3 bucket "{bucket}" exists'))
+def confirm_s3_bucket_exists(bucket, aws_s3_client, workspace, env):
     project = config.get("project")
-    bucket = bucket_type
+    bucket = bucket
     logger.info(f"project: {project}, bucket: {bucket}, env: {env}, workspace: {workspace}")
     if workspace=="":
         bucket_name = project + "-" + bucket + "-" + env

--- a/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
+++ b/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
@@ -4,9 +4,9 @@ from pytest_bdd import scenarios, given, when, then, parsers
 from config import config
 from loguru import logger
 import sys
-import os
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+sys.path.append(str(Path(__file__).resolve().parents[3]))
 from utilities.infra.s3_util import S3Utils
 
 # Load feature file

--- a/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
+++ b/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
@@ -30,7 +30,6 @@ def check_aws_access():
 @then(parsers.parse('The S3 bucket "{bucket}" exists'))
 def confirm_s3_bucket_exists(bucket, aws_s3_client, workspace, env):
     project = config.get("project")
-    bucket = bucket
     logger.info(f"project: {project}, bucket: {bucket}, env: {env}, workspace: {workspace}")
     if workspace=="":
         bucket_name = project + "-" + bucket + "-" + env

--- a/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
+++ b/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
@@ -2,7 +2,6 @@ import pytest
 import subprocess
 from pytest_bdd import scenarios, given, when, then, parsers
 from config import config
-import allure
 from loguru import logger
 import sys
 import os
@@ -21,31 +20,29 @@ def aws_s3_client():
 @pytest.fixture
 def fetch_s3_buckets(aws_s3_client):
     """Retrieve list of S3 buckets (Fixture)"""
-    with allure.step(f"authenticate with AWS CLI: {aws_s3_client.list_buckets()}"):
-        logger.info("Fetching list of S3 buckets...")
-        return aws_s3_client.list_buckets()
+    logger.info("Fetching list of S3 buckets...")
+    return aws_s3_client.list_buckets()
 
 @given("I am authenticated with AWS CLI")
 def check_aws_access():
     """Ensure AWS CLI authentication works"""
     result = subprocess.run(["aws", "sts", "get-caller-identity"], capture_output=True, text=True)
-    with allure.step(f"authenticate with AWS CLI: {result.returncode}"):
-        logger.info("AWS CLI Authenticate", result.returncode)
-        assert result.returncode == 0, f"Failed to authenticate with AWS CLI: {result.stderr}"
+    logger.info("AWS CLI Authenticate", result.returncode)
+    assert result.returncode == 0, f"Failed to authenticate with AWS CLI: {result.stderr}"
 
 
-@then(parsers.parse('The S3 bucket exists'), target_fixture='fbucket_name')
-def confirm_s3_bucket_exists(aws_s3_client, workspace, env):
+@then(parsers.parse('The S3 bucket "{bucket_type}" exists'), target_fixture='fbucket_type')
+def confirm_s3_bucket_exists(bucket_type, aws_s3_client, workspace, env):
     project = config.get("project")
     bucket = config.get("bucket_type")
+    logger.info(f"project: {project}, bucket: {bucket}, env: {env}, workspace: {workspace}")
     if workspace=="":
         bucket_name = project + "-" + bucket + "-" + env
     else:
         bucket_name = project + "-" + bucket + "-" + env + "-" + workspace
     response = aws_s3_client.check_bucket_exists(bucket_name)
-    with allure.step(f"Response: {response}"):
-        logger.info("Bucket Exits: {}", response)
-        assert response == True
+    logger.info("Bucket Exits: {}", response)
+    assert response == True
 
 @when("I fetch the list of S3 buckets")
 def fetch_buckets(aws_s3_client):
@@ -56,15 +53,13 @@ def fetch_buckets(aws_s3_client):
 def validate_bucket_names(fetch_s3_buckets):
     """Validate AWS S3 bucket naming rules"""
     bucket_names = fetch_s3_buckets
-    with allure.step(f"Available Buckets: {bucket_names}"):
-        logger.info("Available Buckets: {}", bucket_names)
-        assert bucket_names, "No buckets found!"
+    logger.info("Available Buckets: {}", bucket_names)
+    assert bucket_names, "No buckets found!"
     for bucket in bucket_names:
-        with allure.step(f"Valid Bucket Names: {bucket_names}"):
-            logger.info("Valid Bucket Names: {}", bucket_names)
-            assert 3 <= len(bucket) <= 63, f"Invalid length for bucket {bucket}"
-            assert bucket.islower(), f"Bucket {bucket} must be lowercase"
-            assert bucket[0].isalnum() and bucket[-1].isalnum(), f"Bucket {bucket} must start & end with letter/number"
-            assert ".." not in bucket, f"Bucket {bucket} contains consecutive dots"
-            assert not bucket.startswith("xn--"), f"Bucket {bucket} cannot start with 'xn--'"
-            assert not bucket.endswith("-s3alias"), f"Bucket {bucket} cannot end with '-s3alias'"
+        logger.info("Valid Bucket Names: {}", bucket_names)
+        assert 3 <= len(bucket) <= 63, f"Invalid length for bucket {bucket}"
+        assert bucket.islower(), f"Bucket {bucket} must be lowercase"
+        assert bucket[0].isalnum() and bucket[-1].isalnum(), f"Bucket {bucket} must start & end with letter/number"
+        assert ".." not in bucket, f"Bucket {bucket} contains consecutive dots"
+        assert not bucket.startswith("xn--"), f"Bucket {bucket} cannot start with 'xn--'"
+        assert not bucket.endswith("-s3alias"), f"Bucket {bucket} cannot end with '-s3alias'"

--- a/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
+++ b/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
@@ -30,7 +30,7 @@ def check_aws_access():
 @then(parsers.parse('The S3 bucket "{bucket_type}" exists'), target_fixture='fbucket_type')
 def confirm_s3_bucket_exists(bucket_type, aws_s3_client, workspace, env):
     project = config.get("project")
-    bucket = config.get("bucket_type")
+    bucket = bucket_type
     logger.info(f"project: {project}, bucket: {bucket}, env: {env}, workspace: {workspace}")
     if workspace=="":
         bucket_name = project + "-" + bucket + "-" + env

--- a/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
+++ b/tests/infra_automation/tests/step_definitions/test_s3_bucket.py
@@ -3,10 +3,6 @@ import subprocess
 from pytest_bdd import scenarios, given, when, then, parsers
 from config import config
 from loguru import logger
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[3]))
 from utilities.infra.s3_util import S3Utils
 
 # Load feature file

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,6 @@
 pytest==8.3.4                   # Core test library
 pytest-bdd==8.1.0               # For BDD-style testing using pytest
 playwright==1.50.0              # Playwright for browser automation
-requests==2.28.2                # HTTP requests handling (if required for other API interactions)
 jsonschema==4.17.0              # JSON schema validation library (if needed for response validation)
 pytest-html==4.1.1              # For generating HTML reports
 pytest-metadata==3.1.1         # Adds metadata to the test reports

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,7 +6,7 @@ requests==2.28.2                # HTTP requests handling (if required for other 
 jsonschema==4.17.0              # JSON schema validation library (if needed for response validation)
 pytest-html==4.1.1              # For generating HTML reports
 pytest-metadata==3.1.1         # Adds metadata to the test reports
-allure-pytest==2.13.5          # Allure integration for beautiful test reports
+allure-pytest-bdd==2.13.5          # Allure integration for beautiful test reports
 pyyaml==6.0.2                  # For YAML-based configuration management
 loguru==0.6.0                  # For better logging management (optional)
 boto3==1.34.49                 # AWS SDK for Python


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Add allure-pytest-bdd to the api test framework to enable more comprehensive report outputs
https://allurereport.org/docs/pytestbdd/
Example commands
To run the tests and save the report results to a folder called allure-results
pytest -p allure_pytest_bdd --alluredir=allure-results
To generate a single page report in the folder allure-report
 allure generate --single-file -c -o allure-reports allure-results

## Context

To be able to generate single page test reports that can be easily shared and read

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
