### PR TITLE
FDOS-200 Update gitleaks with additional rules

### DIFF
--- a/scripts/config/gitleaks.toml
+++ b/scripts/config/gitleaks.toml
@@ -16,4 +16,61 @@ regexes = [
 ]
 
 [allowlist]
-paths = ['''.terraform.lock.hcl''', '''poetry.lock''', '''yarn.lock''', '''scripts/workflow/create-vpn-client-cert.sh''']
+paths = [
+  '''.terraform.lock.hcl''',
+  '''.poetry.lock''',
+  '''yarn.lock''',
+  '''scripts/workflow/create-vpn-client-cert.sh''',
+  '''services/data-migration/tests/unit/'''
+]
+regexes = [
+  '''=========================================''',
+  '''(.*)017000801446(.*)''', # Allow AWS account number for Lambda Layers
+  '''(.*)336392948345(.*)''',
+  '''(.*)XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'''
+]
+
+[[rules]]
+description = "DynamoDB Endpoints"
+id = "dynamodb"
+regex = '''dynamodb\.[a-z]{2}[a-z-]*[1,2,3]\.amazonaws\.com'''
+
+[[rules]]
+description = "Generic ARN"
+id = "arn"
+regex = '''arn:aws:(.*):(.*):[0-9]{12}'''
+
+[[rules]]
+description = "S3 ARN"
+id = "arns3"
+regex = '''arn:aws:s3:::(.*)'''
+
+[[rules]]
+description = "Standard Certificate"
+id = "standardcertificate"
+regex = '''-----BEGIN(\s)CERTIFICATE-----\n'''
+
+[[rules]]
+description = "Private Keys"
+id = "privatekeys"
+regex = '''\s*(\bBEGIN\b).*(PRIVATE KEY\b)\s*'''
+
+[[rules]]
+id = "secretaccesskey"
+description = "AWS Secret Access Key"
+regex = '''(AWS|aws|Aws)?_?(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)?\s*(:|=>|=)\s*[A-Za-z0-9/\+=]{40}\n'''
+
+[[rules]]
+id = "genericawsacno"
+description = "Generic 12 digit AWS acccount number"
+regex = '''\b\d{12}\b'''
+
+[[rules]]
+id = "awsaccountid"
+description = "AWS Account ID"
+regex = '''(AWS|aws|Aws)?_?(ACCOUNT|account|Account)_?(ID|id|Id)?\s*(:|=>|=)\s*[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}'''
+
+[[rules]]
+id = "apikey"
+description = "Generic API Key"
+regex = '''(?i)(api|apikey|key|token)[=:]['"]?[A-Za-z0-9-_]{20,}['"]?'''


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Update gitleaks Configuration with Additional Rules and Exclusions
- Added new rules to detect:
- AWS account numbers (generic 12-digit and labeled format)
- AWS secret access keys
- ARNs (generic and S3-specific)
- DynamoDB endpoints
- Certificates and private keys
- API Keys

Excluded the following:
- The services/data-migration/tests/unit/ directory from scanning
- Allow AWS account numbers for Lambda Layers (specifically for accounts 017000801446 and 336392948345)

## Context

<!-- Why is this change required? What problem does it solve? -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
