### PR TITLE
SIA-662 added constant, changed return type, fixed organisation unit test

### DIFF
--- a/services/crud-apis/organisations/app/router/organisation.py
+++ b/services/crud-apis/organisations/app/router/organisation.py
@@ -15,6 +15,8 @@ from organisations.app.services.organisation_helpers import (
 from organisations.app.services.validators import UpdatePayloadValidator
 from utils.db_service import get_service_repository
 
+ERROR_MESSAGE_404 = "Organisation not found"
+
 router = APIRouter()
 org_repository = get_service_repository(Organisation, "organisation")
 
@@ -36,7 +38,7 @@ def get_org_by_ods_code(
             CrudApisLogBase.ORGANISATION_002,
             ods_code=ods_code,
         )
-        raise HTTPException(status_code=404, detail="Organisation not found")
+        raise HTTPException(status_code=404, detail=ERROR_MESSAGE_404)
 
     return JSONResponse(status_code=200, content={"id": records[0]})
 
@@ -61,7 +63,7 @@ def get_organisation_by_id(
             CrudApisLogBase.ORGANISATION_009,
             organisation_id=organisation_id,
         )
-        raise HTTPException(status_code=404, detail="Organisation not found")
+        raise HTTPException(status_code=404, detail=ERROR_MESSAGE_404)
 
     return organisation
 
@@ -89,7 +91,7 @@ def update_organisation(
         description="The internal id of the organisation",
     ),
     payload: UpdatePayloadValidator = Body(...),
-) -> dict:
+) -> JSONResponse:
     crud_organisation_logger.log(
         CrudApisLogBase.ORGANISATION_005,
         organisation_id=organisation_id,
@@ -98,7 +100,7 @@ def update_organisation(
 
     if not organisation:
         logging.error(f"Organisation with ID {organisation_id} not found.")
-        raise HTTPException(status_code=404, detail="Organisation not found")
+        raise HTTPException(status_code=404, detail=ERROR_MESSAGE_404)
 
     outdated_fields = get_outdated_fields(organisation, payload)
     crud_organisation_logger.log(

--- a/services/crud-apis/organisations/tests/unit/test_organisation.py
+++ b/services/crud-apis/organisations/tests/unit/test_organisation.py
@@ -161,8 +161,8 @@ def test_update_organisation_validation_error(mock_repository: MockerFixture) ->
     }
     with pytest.raises(RequestValidationError) as exc_info:
         client.put(f"/{test_org_id}", json=update_payload)
-        assert exc_info.type == RequestValidationError
-        assert "field required" in str(exc_info.value)
+    assert exc_info.type == RequestValidationError
+    assert  exc_info.value.detail == "field required"
 
 
 def test_get_organisation_by_ods_code_success(mock_repository: MockerFixture) -> None:

--- a/services/crud-apis/organisations/tests/unit/test_organisation.py
+++ b/services/crud-apis/organisations/tests/unit/test_organisation.py
@@ -162,7 +162,7 @@ def test_update_organisation_validation_error(mock_repository: MockerFixture) ->
     with pytest.raises(RequestValidationError) as exc_info:
         client.put(f"/{test_org_id}", json=update_payload)
         assert exc_info.type == RequestValidationError
-    assert "field required" in str(exc_info.value)
+    assert "Name cannot be empty" in str(exc_info.value)
 
 
 def test_get_organisation_by_ods_code_success(mock_repository: MockerFixture) -> None:

--- a/services/crud-apis/organisations/tests/unit/test_organisation.py
+++ b/services/crud-apis/organisations/tests/unit/test_organisation.py
@@ -161,8 +161,8 @@ def test_update_organisation_validation_error(mock_repository: MockerFixture) ->
     }
     with pytest.raises(RequestValidationError) as exc_info:
         client.put(f"/{test_org_id}", json=update_payload)
-    assert exc_info.type == RequestValidationError
-    assert "field required" in str(exc_info.value)
+        assert exc_info.type == RequestValidationError
+        assert "field required" in str(exc_info.value)
 
 
 def test_get_organisation_by_ods_code_success(mock_repository: MockerFixture) -> None:

--- a/services/crud-apis/organisations/tests/unit/test_organisation.py
+++ b/services/crud-apis/organisations/tests/unit/test_organisation.py
@@ -161,8 +161,8 @@ def test_update_organisation_validation_error(mock_repository: MockerFixture) ->
     }
     with pytest.raises(RequestValidationError) as exc_info:
         client.put(f"/{test_org_id}", json=update_payload)
-        assert exc_info.type == RequestValidationError
-        assert "field required" in str(exc_info.value)
+    assert exc_info.type == RequestValidationError
+    assert "field required" in str(exc_info.value)
 
 
 def test_get_organisation_by_ods_code_success(mock_repository: MockerFixture) -> None:

--- a/services/crud-apis/organisations/tests/unit/test_organisation.py
+++ b/services/crud-apis/organisations/tests/unit/test_organisation.py
@@ -162,7 +162,7 @@ def test_update_organisation_validation_error(mock_repository: MockerFixture) ->
     with pytest.raises(RequestValidationError) as exc_info:
         client.put(f"/{test_org_id}", json=update_payload)
     assert exc_info.type == RequestValidationError
-    assert  exc_info.value.detail == "field required"
+    assert exc_info.value.detail == "field required"
 
 
 def test_get_organisation_by_ods_code_success(mock_repository: MockerFixture) -> None:

--- a/services/crud-apis/organisations/tests/unit/test_organisation.py
+++ b/services/crud-apis/organisations/tests/unit/test_organisation.py
@@ -162,7 +162,7 @@ def test_update_organisation_validation_error(mock_repository: MockerFixture) ->
     with pytest.raises(RequestValidationError) as exc_info:
         client.put(f"/{test_org_id}", json=update_payload)
         assert exc_info.type == RequestValidationError
-        assert "field required" in str(exc_info.value)
+    assert "field required" in str(exc_info.value)
 
 
 def test_get_organisation_by_ods_code_success(mock_repository: MockerFixture) -> None:

--- a/services/crud-apis/organisations/tests/unit/test_organisation.py
+++ b/services/crud-apis/organisations/tests/unit/test_organisation.py
@@ -161,9 +161,8 @@ def test_update_organisation_validation_error(mock_repository: MockerFixture) ->
     }
     with pytest.raises(RequestValidationError) as exc_info:
         client.put(f"/{test_org_id}", json=update_payload)
-    assert exc_info.type == RequestValidationError
-    assert exc_info.value.detail == "field required"
-
+        assert exc_info.type == RequestValidationError
+    assert "field required" in str(exc_info.value)
 
 def test_get_organisation_by_ods_code_success(mock_repository: MockerFixture) -> None:
     mock_repository.get_by_ods_code.return_value = ["uuid"]

--- a/services/crud-apis/organisations/tests/unit/test_organisation.py
+++ b/services/crud-apis/organisations/tests/unit/test_organisation.py
@@ -161,7 +161,7 @@ def test_update_organisation_validation_error(mock_repository: MockerFixture) ->
     }
     with pytest.raises(RequestValidationError) as exc_info:
         client.put(f"/{test_org_id}", json=update_payload)
-        assert exc_info.type == RequestValidationError
+    assert exc_info.type == RequestValidationError
     assert "Name cannot be empty" in str(exc_info.value)
 
 

--- a/services/crud-apis/organisations/tests/unit/test_organisation.py
+++ b/services/crud-apis/organisations/tests/unit/test_organisation.py
@@ -162,7 +162,7 @@ def test_update_organisation_validation_error(mock_repository: MockerFixture) ->
     with pytest.raises(RequestValidationError) as exc_info:
         client.put(f"/{test_org_id}", json=update_payload)
         assert exc_info.type == RequestValidationError
-    assert "field required" in str(exc_info.value)
+        assert "field required" in str(exc_info.value)
 
 
 def test_get_organisation_by_ods_code_success(mock_repository: MockerFixture) -> None:

--- a/services/crud-apis/organisations/tests/unit/test_organisation.py
+++ b/services/crud-apis/organisations/tests/unit/test_organisation.py
@@ -164,6 +164,7 @@ def test_update_organisation_validation_error(mock_repository: MockerFixture) ->
         assert exc_info.type == RequestValidationError
     assert "field required" in str(exc_info.value)
 
+
 def test_get_organisation_by_ods_code_success(mock_repository: MockerFixture) -> None:
     mock_repository.get_by_ods_code.return_value = ["uuid"]
     ods_code = "12345"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Added constant for the `404` error message in crud-apis and changed the return type on `update_organisation`
Also changed the assert value on one of the organisation tests so that we are asserting after the object is created.
## Context

<!-- Why is this change required? What problem does it solve? -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
