### PR TITLE
FDOS-401 Add ssm parameters for account ids for cross account permissions

### DIFF
--- a/infrastructure/common.tfvars
+++ b/infrastructure/common.tfvars
@@ -15,3 +15,9 @@ dynamodb_table_names = [
   "location",
   "organisation"
 ]
+
+aws_accounts = [
+  "dev",
+  "test",
+  "prod"
+]

--- a/infrastructure/common/common-variables.tf
+++ b/infrastructure/common/common-variables.tf
@@ -85,3 +85,8 @@ variable "vpc" {
   type        = map(any)
   default     = {}
 }
+
+variable "aws_accounts" {
+  description = "List of AWS account environments"
+  type        = list(string)
+}

--- a/infrastructure/stacks/domain_name/ssm-parameters.tf
+++ b/infrastructure/stacks/domain_name/ssm-parameters.tf
@@ -1,0 +1,23 @@
+resource "aws_ssm_parameter" "ssm_aws_account_id" {
+  for_each = var.environment == "mgmt" ? { for account in var.aws_accounts : account => account } : {}
+
+  name        = "/${var.project}/${each.key}/aws_account_id"
+  description = "ID of the ${each.key} AWS account"
+  type        = "SecureString"
+  tier        = "Standard"
+  value       = "default" # Placeholder, to be manually updated in AWS Console or via CLI later
+
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
+}
+
+# locals {
+#   allowed_account_ids = [
+#     data.aws_ssm_parameter.dev_account_id.value,
+#     data.aws_ssm_parameter.test_account_id.value,
+#     data.aws_ssm_parameter.prod_account_id.value,
+#   ]
+# }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Add ssm parameters for account ids for cross account permissions to be introduced later

## Context

<!-- Why is this change required? What problem does it solve? -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
