### PR TITLE
SIA-671 Enabling default endpoint CRUD API

### DIFF
--- a/infrastructure/stacks/crud_apis/api_gateway.tf
+++ b/infrastructure/stacks/crud_apis/api_gateway.tf
@@ -1,9 +1,10 @@
 module "api_gateway" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2.git?ref=5d1548624b39145ead043794ae5762abb9aadb27"
 
-  name                         = "${local.resource_prefix}-api-gateway${local.workspace_suffix}"
-  protocol_type                = "HTTP"
-  disable_execute_api_endpoint = true
+  name          = "${local.resource_prefix}-api-gateway${local.workspace_suffix}"
+  protocol_type = "HTTP"
+  # TODO: To be disabled after APIM and ETL integration start using mTLS endpoint (SIA-647 & SIA-649)
+  # disable_execute_api_endpoint = true
 
   create_domain_name    = false
   create_domain_records = false

--- a/infrastructure/stacks/crud_apis/api_gateway.tf
+++ b/infrastructure/stacks/crud_apis/api_gateway.tf
@@ -3,7 +3,7 @@ module "api_gateway" {
 
   name          = "${local.resource_prefix}-api-gateway${local.workspace_suffix}"
   protocol_type = "HTTP"
-  # TODO: To be disabled after APIM, ETL and Dos Reader integration start using mTLS endpoint (SIA-647 & SIA-649)
+  # TODO: To be disabled after APIM, ETL and Dos Reader integration start using mTLS endpoint (SIA-647 & SIA-649 & TBC )
   # disable_execute_api_endpoint = true
 
   create_domain_name    = false

--- a/infrastructure/stacks/crud_apis/api_gateway.tf
+++ b/infrastructure/stacks/crud_apis/api_gateway.tf
@@ -3,7 +3,7 @@ module "api_gateway" {
 
   name          = "${local.resource_prefix}-api-gateway${local.workspace_suffix}"
   protocol_type = "HTTP"
-  # TODO: To be disabled after APIM and ETL integration start using mTLS endpoint (SIA-647 & SIA-649)
+  # TODO: To be disabled after APIM, ETL and Dos Reader integration start using mTLS endpoint (SIA-647 & SIA-649)
   # disable_execute_api_endpoint = true
 
   create_domain_name    = false


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Enabling default endpoint to have no blockers. Currently some testing tickets and existing functionality are getting blocked as integrations are still using the default endpoint. This will be enabled after all integrations have been migrated to use mTLS endpoint.

## Context

<!-- Why is this change required? What problem does it solve? -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
