### PR TITLE
Removing IAM authoriser for organisation endpoint

### DIFF
--- a/infrastructure/stacks/crud_apis/api_gateway.tf
+++ b/infrastructure/stacks/crud_apis/api_gateway.tf
@@ -12,7 +12,6 @@ module "api_gateway" {
   # TODO: FDOS-370 - Setup to use mTLS or API Keys
   routes = {
     "ANY /organisation/{proxy+}" = {
-      authorization_type = var.api_gateway_authorization_type
       integration = {
         uri                    = module.organisation_api_lambda.lambda_function_arn
         payload_format_version = var.api_gateway_payload_format_version


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Removed IAM authoriser for /organisation endpoint as CRUD API is now secured via mTLS

## Context

<!-- Why is this change required? What problem does it solve? -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
