### PR TITLE
FDOS-336 Add environment name to workflows

### DIFF
--- a/.github/workflows/pipeline-deploy-account-infrastructure.yaml
+++ b/.github/workflows/pipeline-deploy-account-infrastructure.yaml
@@ -43,7 +43,7 @@ jobs:
     uses: ./.github/workflows/metadata.yaml
 
   quality-checks:
-    name: "Quality check"
+    name: "Quality checks for ${{ needs.metadata.outputs.environment }} deployment"
     needs:
       - metadata
     uses: ./.github/workflows/quality-checks.yaml
@@ -60,6 +60,7 @@ jobs:
       - metadata
       - quality-checks
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: "account"
@@ -82,7 +83,7 @@ jobs:
     secrets: inherit
 
   manual-approval:
-    name: "Manual approval for infrastructure deployment"
+    name: "Manual approval for ${{ needs.metadata.outputs.environment }} infrastructure deployment"
     if: ${{ github.ref == 'refs/heads/main' && (needs.plan-infrastructure.outputs.plan_result == 'true') }}
     needs:
       - metadata
@@ -91,7 +92,7 @@ jobs:
     environment: "${{ needs.metadata.outputs.environment }}-protected"
     steps:
       - name: Approval required
-        run: echo "Deployment paused for manual approval. Please approve in the Actions tab."
+        run: echo "${{ needs.metadata.outputs.environment }} deployment paused for manual approval. Please approve in the Actions tab."
 
   apply-infrastructure:
     name: "Apply ${{ matrix.name }} infrastructure deployment for ${{ matrix.environment }}"
@@ -100,6 +101,7 @@ jobs:
       - metadata
       - manual-approval
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: "account"

--- a/.github/workflows/pipeline-deploy-application.yaml
+++ b/.github/workflows/pipeline-deploy-application.yaml
@@ -40,7 +40,7 @@ jobs:
     uses: ./.github/workflows/metadata.yaml
 
   quality-checks:
-    name: "Quality check"
+    name: "Quality checks for ${{ needs.metadata.outputs.environment }} deployment"
     needs:
       - metadata
     uses: ./.github/workflows/quality-checks.yaml
@@ -95,7 +95,7 @@ jobs:
     secrets: inherit
 
   plan-infrastructure:
-    name: "Plan application infrastructure deployment"
+    name: "Plan ${{ needs.metadata.outputs.environment }} application infrastructure deployment"
     concurrency:
       group: "${{ needs.metadata.outputs.environment }}-protected"
       cancel-in-progress: false
@@ -115,7 +115,7 @@ jobs:
     secrets: inherit
 
   manual-approval:
-    name: "Manual approval for deployment deployment"
+    name: "Manual approval for ${{ needs.metadata.outputs.environment }} deployment"
     if: ${{ needs.plan-infrastructure.outputs.plan_result == 'true' }}
     needs:
       - metadata
@@ -124,10 +124,10 @@ jobs:
     environment: "${{ needs.metadata.outputs.environment }}-protected"
     steps:
       - name: Approval required
-        run: echo "Deployment paused for manual approval. Please approve in the Actions tab."
+        run: echo "${{ needs.metadata.outputs.environment }} deployment paused for manual approval. Please approve in the Actions tab."
 
   apply-infrastructure:
-    name: "Apply application infrastructure"
+    name: "Apply ${{ needs.metadata.outputs.environment }} application infrastructure"
     concurrency:
       group: "${{ needs.metadata.outputs.environment }}-protected"
       cancel-in-progress: false
@@ -147,7 +147,7 @@ jobs:
     secrets: inherit
 
   deploy-read-only-viewer-service:
-    name: "Deploy read only viewer service"
+    name: "Deploy read only viewer service to ${{ needs.metadata.outputs.environment }}"
     concurrency:
       group: "${{ needs.metadata.outputs.environment }}-protected"
       cancel-in-progress: false
@@ -168,7 +168,7 @@ jobs:
     secrets: inherit
 
   service-automation-tests:
-    name: Run service automation tests
+    name: "Run service automation tests on ${{ needs.metadata.outputs.environment }}"
     needs:
       - metadata
       - apply-infrastructure


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Add environment name to workflows and disable fail-fast for account matrix strategies to allow all jobs to complete.

## Context

<!-- Why is this change required? What problem does it solve? -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
