### PR TITLE
FDOS-336 Replace data source for organisation table with local refer…

### DIFF
--- a/infrastructure/common.tfvars
+++ b/infrastructure/common.tfvars
@@ -25,3 +25,5 @@ aws_accounts = [
 root_domain_name = "ftrs.cloud.nhs.uk"
 
 s3_trust_store_bucket_name = "truststore"
+
+gp_search_organisation_table_name = "organisation"

--- a/infrastructure/common/common-variables.tf
+++ b/infrastructure/common/common-variables.tf
@@ -111,3 +111,8 @@ variable "sso_roles" {
   type        = list(string)
   default     = []
 }
+
+variable "gp_search_organisation_table_name" {
+  description = "The dynamodb table name for gp search"
+  type        = string
+}

--- a/infrastructure/common/locals.tf
+++ b/infrastructure/common/locals.tf
@@ -19,7 +19,7 @@ locals {
     }
   }
 
-  organisation_table_arn = local.dynamodb_tables["organisation"].arn
+  gp_search_organisation_table_arn = "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${var.project}-${var.environment}-database-${var.gp_search_organisation_table_name}"
 
   domain_cross_account_role = "${var.repo_name}-mgmt-domain-name-cross-account-access"
 

--- a/infrastructure/common/locals.tf
+++ b/infrastructure/common/locals.tf
@@ -19,6 +19,8 @@ locals {
     }
   }
 
+  organisation_table_arn = local.dynamodb_tables["organisation"].arn
+
   domain_cross_account_role = "${var.repo_name}-mgmt-domain-name-cross-account-access"
 
   env_domain_name = "${var.environment}.${var.root_domain_name}"

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -27,3 +27,5 @@ sso_roles = [
 
 enable_flow_log           = false
 flow_log_s3_force_destroy = true
+
+gp_search_organisation_table_name = "organisation-is"

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -25,3 +25,5 @@ sso_roles = [
 
 enable_flow_log           = true
 flow_log_s3_force_destroy = true
+
+gp_search_organisation_table_name = "organisation-is"

--- a/infrastructure/gp_search.tfvars
+++ b/infrastructure/gp_search.tfvars
@@ -11,4 +11,4 @@ lambda_timeout     = 900
 lambda_memory_size = 512
 
 #DynamoDB
-dynamodb_organisation_table_name = "ftrs-dos-dev-database-organisation-is"
+gp_search_organisation_table_name = "organisation"

--- a/infrastructure/gp_search.tfvars
+++ b/infrastructure/gp_search.tfvars
@@ -9,6 +9,3 @@ health_check_lambda_name = "health-check-lambda"
 lambda_runtime     = "python3.12"
 lambda_timeout     = 900
 lambda_memory_size = 512
-
-#DynamoDB
-gp_search_organisation_table_name = "organisation"

--- a/infrastructure/stacks/gp_search/data.tf
+++ b/infrastructure/stacks/gp_search/data.tf
@@ -22,10 +22,6 @@ data "aws_subnet" "private_subnets_details" {
   id       = each.value
 }
 
-data "aws_dynamodb_table" "dynamodb_organisation_table" {
-  name = var.dynamodb_organisation_table_name
-}
-
 data "aws_route53_zone" "dev_ftrs_cloud" {
   name         = local.root_domain_name
   private_zone = false

--- a/infrastructure/stacks/gp_search/health_check_lambda.tf
+++ b/infrastructure/stacks/gp_search/health_check_lambda.tf
@@ -24,7 +24,7 @@ module "health_check_lambda" {
     "ENVIRONMENT"         = var.environment
     "PROJECT_NAME"        = var.project
     "NAMESPACE"           = "${var.gp_search_service_name}${local.workspace_suffix}"
-    "DYNAMODB_TABLE_NAME" = var.dynamodb_organisation_table_name
+    "DYNAMODB_TABLE_NAME" = "${var.project}-${var.environment}-database-${var.gp_search_organisation_table_name}"
   }
 }
 
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "health_check_dynamodb_access_policy" {
       "dynamodb:DescribeTable",
     ]
     resources = [
-      local.organisation_table_arn
+      local.gp_search_organisation_table_arn
     ]
   }
 }

--- a/infrastructure/stacks/gp_search/health_check_lambda.tf
+++ b/infrastructure/stacks/gp_search/health_check_lambda.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "health_check_dynamodb_access_policy" {
       "dynamodb:DescribeTable",
     ]
     resources = [
-      data.aws_dynamodb_table.dynamodb_organisation_table.arn,
+      local.organisation_table_arn
     ]
   }
 }

--- a/infrastructure/stacks/gp_search/search_lambda.tf
+++ b/infrastructure/stacks/gp_search/search_lambda.tf
@@ -33,7 +33,7 @@ module "lambda" {
     "ENVIRONMENT"         = var.environment
     "PROJECT_NAME"        = var.project
     "NAMESPACE"           = "${var.gp_search_service_name}${local.workspace_suffix}"
-    "DYNAMODB_TABLE_NAME" = var.gp_search_organisation_table_name
+    "DYNAMODB_TABLE_NAME" = "${var.project}-${var.environment}-database-${var.gp_search_organisation_table_name}"
   }
 }
 

--- a/infrastructure/stacks/gp_search/search_lambda.tf
+++ b/infrastructure/stacks/gp_search/search_lambda.tf
@@ -33,7 +33,7 @@ module "lambda" {
     "ENVIRONMENT"         = var.environment
     "PROJECT_NAME"        = var.project
     "NAMESPACE"           = "${var.gp_search_service_name}${local.workspace_suffix}"
-    "DYNAMODB_TABLE_NAME" = var.dynamodb_organisation_table_name
+    "DYNAMODB_TABLE_NAME" = var.gp_search_organisation_table_name
   }
 }
 
@@ -69,8 +69,8 @@ data "aws_iam_policy_document" "dynamodb_access_policy" {
       "dynamodb:Query",
     ]
     resources = [
-      "${local.organisation_table_arn}/",
-      "${local.organisation_table_arn}/*"
+      "${local.gp_search_organisation_table_arn}/",
+      "${local.gp_search_organisation_table_arn}/*"
     ]
   }
 }

--- a/infrastructure/stacks/gp_search/search_lambda.tf
+++ b/infrastructure/stacks/gp_search/search_lambda.tf
@@ -69,8 +69,8 @@ data "aws_iam_policy_document" "dynamodb_access_policy" {
       "dynamodb:Query",
     ]
     resources = [
-      "${data.aws_dynamodb_table.dynamodb_organisation_table.arn}/",
-      "${data.aws_dynamodb_table.dynamodb_organisation_table.arn}/*"
+      "${local.organisation_table_arn}/",
+      "${local.organisation_table_arn}/*"
     ]
   }
 }

--- a/infrastructure/stacks/gp_search/variables.tf
+++ b/infrastructure/stacks/gp_search/variables.tf
@@ -29,7 +29,7 @@ variable "commit_hash" {
   description = "The commit hash of the gp search application"
   type        = string
 }
-variable "dynamodb_organisation_table_name" {
+variable "gp_search_organisation_table_name" {
   description = "The dynamodb table name for gp search"
   type        = string
 }

--- a/infrastructure/stacks/gp_search/variables.tf
+++ b/infrastructure/stacks/gp_search/variables.tf
@@ -29,11 +29,6 @@ variable "commit_hash" {
   description = "The commit hash of the gp search application"
   type        = string
 }
-variable "gp_search_organisation_table_name" {
-  description = "The dynamodb table name for gp search"
-  type        = string
-}
-
 variable "retention_in_days" {
   description = "The retention period in days for anything that can be retained"
   type        = number


### PR DESCRIPTION
…ence

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Replace data source for organisation DynamoDB table with local ARN reference

- Removed `data.aws_dynamodb_table` lookup for organisation table
- Used `locals.dynamodb_tables["organisation"].arn` to construct ARN directly
- Reduces dependency on AWS state during plan when table is not yet created

## Context

<!-- Why is this change required? What problem does it solve? -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
