### PR TITLE
FDOS-310 Allow for optional creation of entity types

### DIFF
--- a/services/data-migration/pipeline/processor.py
+++ b/services/data-migration/pipeline/processor.py
@@ -130,9 +130,12 @@ class DataMigrationProcessor:
                 DataMigrationLogBase.DM_ETL_007,
                 elapsed_time=elapsed_time,
                 transformer_name=transformer.__class__.__name__,
-                healthcare_service_id=result.healthcare_service.id,
-                organisation_id=result.organisation.id,
-                location_id=result.location.id,
+                healthcare_service_count=len(result.healthcare_service),
+                location_count=len(result.location),
+                organisation_count=len(result.organisation),
+                healthcare_service_ids=[hs.id for hs in result.healthcare_service],
+                location_ids=[loc.id for loc in result.location],
+                organisation_ids=[org.id for org in result.organisation],
             )
 
         except Exception as e:
@@ -183,9 +186,14 @@ class DataMigrationProcessor:
         location_repo = self.get_repository("location", Location)
         service_repo = self.get_repository("healthcare-service", HealthcareService)
 
-        org_repo.upsert(result.organisation)
-        location_repo.upsert(result.location)
-        service_repo.upsert(result.healthcare_service)
+        for org in result.organisation:
+            org_repo.upsert(org)
+
+        for loc in result.location:
+            location_repo.upsert(loc)
+
+        for hc in result.healthcare_service:
+            service_repo.upsert(hc)
 
     # TODO: Remove this method and use the common function once merged by IS
     def get_repository(

--- a/services/data-migration/pipeline/transformer/base.py
+++ b/services/data-migration/pipeline/transformer/base.py
@@ -29,7 +29,7 @@ from ftrs_data_layer.domain.clinical_code import (
     SymptomGroup,
     SymptomGroupSymptomDiscriminatorPair,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from pipeline.utils.cache import DoSMetadataCache
 
@@ -41,9 +41,9 @@ class ServiceTransformOutput(BaseModel):
     This may be adapted in the future to better reflect relationships/data deduplication.
     """
 
-    organisation: Organisation
-    healthcare_service: HealthcareService
-    location: Location
+    organisation: list[Organisation] = Field(default_factory=list)
+    healthcare_service: list[HealthcareService] = Field(default_factory=list)
+    location: list[Location] = Field(default_factory=list)
 
 
 class ServiceTransformer(ABC):

--- a/services/data-migration/pipeline/transformer/gp_practice.py
+++ b/services/data-migration/pipeline/transformer/gp_practice.py
@@ -39,9 +39,9 @@ class GPPracticeTransformer(ServiceTransformer):
         )
 
         return ServiceTransformOutput(
-            organisation=organisation,
-            healthcare_service=healthcare_service,
-            location=location,
+            organisation=[organisation],
+            healthcare_service=[healthcare_service],
+            location=[location],
         )
 
     @classmethod

--- a/services/data-migration/tests/unit/test_cli.py
+++ b/services/data-migration/tests/unit/test_cli.py
@@ -174,9 +174,9 @@ def test_patch_local_save_method(mocker: MockerFixture) -> None:
     hc_path = output_dir / "healthcare-service.jsonl"
 
     mock_output = ServiceTransformOutput(
-        organisation=Organisation.model_construct(id=uuid4()),
-        location=Location.model_construct(id=uuid4()),
-        healthcare_service=HealthcareService.model_construct(id=uuid4()),
+        organisation=[Organisation.model_construct(id=uuid4())],
+        location=[Location.model_construct(id=uuid4())],
+        healthcare_service=[HealthcareService.model_construct(id=uuid4())],
     )
 
     with patch_local_save_method(mock_app, output_dir):
@@ -196,22 +196,30 @@ def test_patch_local_save_method(mocker: MockerFixture) -> None:
     hc_content = json.loads(hc_path.read_text().strip())
 
     assert org_content == {
-        "id": str(mock_output.organisation.id),
+        "id": str(mock_output.organisation[0].id),
+        "identifier_ODS_ODSCode": None,
         "createdBy": "SYSTEM",
         "createdDateTime": "2025-07-15T12:00:00Z",
         "modifiedBy": "SYSTEM",
         "modifiedDateTime": "2025-07-15T12:00:00Z",
         "endpoints": [],
+        "telecom": None,
     }
     assert loc_content == {
-        "id": str(mock_output.location.id),
+        "id": str(mock_output.location[0].id),
+        "name": None,
+        "partOf": None,
+        "positionGCS": None,
+        "positionReferenceNumber_UBRN": None,
+        "positionReferenceNumber_UPRN": None,
         "createdBy": "SYSTEM",
         "createdDateTime": "2025-07-15T12:00:00Z",
         "modifiedBy": "SYSTEM",
         "modifiedDateTime": "2025-07-15T12:00:00Z",
     }
     assert hc_content == {
-        "id": str(mock_output.healthcare_service.id),
+        "id": str(mock_output.healthcare_service[0].id),
+        "identifier_oldDoS_uid": None,
         "createdBy": "SYSTEM",
         "createdDateTime": "2025-07-15T12:00:00Z",
         "modifiedBy": "SYSTEM",

--- a/services/data-migration/tests/unit/test_processor.py
+++ b/services/data-migration/tests/unit/test_processor.py
@@ -183,7 +183,8 @@ def test_process_service(
 
     output = processor._save.call_args[0][0]
     assert isinstance(output, ServiceTransformOutput)
-    assert output.organisation == Organisation(
+    assert len(output.organisation) == 1
+    assert output.organisation[0] == Organisation(
         id="4539600c-e04e-5b35-a582-9fb36858d0e0",
         createdBy="DATA_MIGRATION",
         createdDateTime="2025-07-25T12:00:00+00:00",
@@ -235,7 +236,9 @@ def test_process_service(
             ),
         ],
     )
-    assert output.healthcare_service == HealthcareService(
+
+    assert len(output.healthcare_service) == 1
+    assert output.healthcare_service[0] == HealthcareService(
         id="903cd48b-5d0f-532f-94f4-937a4517b14d",
         createdBy="DATA_MIGRATION",
         createdDateTime="2025-07-25T12:00:00+00:00",
@@ -365,7 +368,9 @@ def test_process_service(
             ),
         ],
     )
-    assert output.location == Location(
+
+    assert len(output.location) == 1
+    assert output.location[0] == Location(
         id="6ef3317e-c6dc-5e27-b36d-577c375eb060",
         createdBy="DATA_MIGRATION",
         createdDateTime="2025-07-25T12:00:00+00:00",
@@ -599,10 +604,10 @@ def test_save(
     processor._save(result)
 
     assert mock_org_repo.upsert.call_count == 1
-    mock_org_repo.upsert.assert_called_once_with(result.organisation)
+    mock_org_repo.upsert.assert_called_once_with(result.organisation[0])
 
     assert mock_location_repo.upsert.call_count == 1
-    mock_location_repo.upsert.assert_called_once_with(result.location)
+    mock_location_repo.upsert.assert_called_once_with(result.location[0])
 
     assert mock_service_repo.upsert.call_count == 1
-    mock_service_repo.upsert.assert_called_once_with(result.healthcare_service)
+    mock_service_repo.upsert.assert_called_once_with(result.healthcare_service[0])

--- a/services/data-migration/tests/unit/transformer/test_gp_practice.py
+++ b/services/data-migration/tests/unit/transformer/test_gp_practice.py
@@ -81,8 +81,16 @@ def test_transform(
     transformer = GPPracticeTransformer(MockLogger(), mock_metadata_cache)
     result = transformer.transform(mock_legacy_service)
 
-    assert result.organisation.identifier_ODS_ODSCode == "A12345"
-    assert result.healthcare_service.category == HealthcareServiceCategory.GP_SERVICES
+    assert len(result.organisation) == 1
+    assert result.organisation[0].identifier_ODS_ODSCode == "A12345"
+
+    assert len(result.location) == 1
+
+    assert len(result.healthcare_service) == 1
     assert (
-        result.healthcare_service.type == HealthcareServiceType.GP_CONSULTATION_SERVICE
+        result.healthcare_service[0].category == HealthcareServiceCategory.GP_SERVICES
+    )
+    assert (
+        result.healthcare_service[0].type
+        == HealthcareServiceType.GP_CONSULTATION_SERVICE
     )


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This ticket facilitates the full development of FDOS-301 by allowing creation of zero or more records of each entity type for a provided service.

For example: [FDOS-366](https://nhsd-jira.digital.nhs.uk/browse/FDOS-366) will only create a HealthcareService resource, without an Organisation or Location record.

## Context

<!-- Why is this change required? What problem does it solve? -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
