### PR TITLE
FDOS-582 Workspace prefix changed from dependabot to bot

### DIFF
--- a/scripts/workflow/derive-workspace.sh
+++ b/scripts/workflow/derive-workspace.sh
@@ -37,7 +37,7 @@ BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/refs\/heads\/task/task/g; s/refs\/hea
 
 if [[ "${BRANCH_NAME:0:10}" == "dependabot" ]]; then
   # Handle dependabot branches
-  WORKSPACE="dependabot-$COMMIT_HASH"
+  WORKSPACE="bot-$COMMIT_HASH"
   echo "Workspace from dependabot branch: $WORKSPACE"
 elif [[ "$BRANCH_NAME" == "main" ]]; then
   # Handle main branch


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Shorten workspace prefix to prevent issues with length of name for S3 buckets
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
